### PR TITLE
fix: body and header empty string issue

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -131,7 +131,7 @@ const TwopiRest = ({
           )
             res = await fetch(`${baseUrl}${url}${queryStr}`, {
               method: `${reqType}`,
-              headers: JSON.parse(header),
+              headers: header === "" ? {} : JSON.parse(header),
             });
 
           if (
@@ -141,8 +141,8 @@ const TwopiRest = ({
           )
             res = await fetch(`${baseUrl}${url}${queryStr}`, {
               method: `${reqType}`,
-              headers: JSON.parse(header),
-              body,
+              headers: header === "" ? {} : JSON.parse(header),
+              body: body === "" ? "{}" : body,
             });
           resStatus = res?.status;
           resJson = await res?.json();


### PR DESCRIPTION
Fixed the bug with a manual check before making the fetch call.